### PR TITLE
Build for correct arch when cross-building (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ bin/flexvol-ppc64le: ARCH=ppc64le
 bin/flexvol-s390x: ARCH=s390x
 bin/flexvol-%: vendor $(SRC_FILES)
 	mkdir -p bin
-	$(DOCKER_GO_BUILD) go build -v -o bin/flexvol-$(ARCH) flexvol/flexvoldriver.go
+	$(DOCKER_GO_BUILD) env GOARCH=$(ARCH) go build -v -o bin/flexvol-$(ARCH) flexvol/flexvoldriver.go
 
 ###############################################################################
 # Building the image


### PR DESCRIPTION
GOARCH wasn't get set so we were ending up with a directory full of binaries for the host arch.

## Description

Pull request as requested by @rafaelvanoni in #17.

Questions asked in template:

 * This is a bug fix
 * It should be merged so that the arm64 Docker image contain an arm64 binary. 
 * I've build an image manually with the fix in place and deployed it on an arm host.
 * It fixes #17 
