### PR TITLE
Allow non-root pods to connect to sockets

### DIFF
--- a/binder/binder.go
+++ b/binder/binder.go
@@ -130,6 +130,13 @@ func (b *binder) addListener(uid string) {
 		log.Printf("failed to listen at %s %v", sockPath, err)
 		return
 	}
+	// We don't know the UID or GID of the pod process, so we need to make this
+	// accessible by anyone.
+	err = os.Chmod(sockPath, 0777)
+	if err != nil {
+		log.Printf("failed to set permissions at %s %v", sockPath, err)
+		return
+	}
 	w.listener = lis
 	b.workloads.store(uid, w)
 


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We desire to run Dikastes as a non-root user, meaning that we need the domain sockets to be read/write available by non-root users.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
