### PR TITLE
Automated cherry pick of #48: Fix make cd target to use correct tag for docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${GIT_VERSION} EXCLUDEARCH="$(EXCLUDEARCH)"
 
 ###############################################################################
 # Release


### PR DESCRIPTION
Cherry pick of #48 on release-v3.16.

#48: Fix make cd target to use correct tag for docker images