### PR TITLE
change flexvol/uds permissions to 0555

### DIFF
--- a/flexvol/docker/flexvol.sh
+++ b/flexvol/docker/flexvol.sh
@@ -61,5 +61,5 @@ if [ -f ${DSTDIR}/${DSTIMAGE} ]; then
 fi
 
 cp ${SRCDIR}/${IMAGE} ${DSTDIR}/.${DSTIMAGE}
-chmod 0550 ${DSTDIR}/.${DSTIMAGE}
+chmod 0555 ${DSTDIR}/.${DSTIMAGE}
 mv ${DSTDIR}/.${DSTIMAGE} ${DSTDIR}/${DSTIMAGE}


### PR DESCRIPTION
There's an issue if `kube-controller-manager` is running as a non-root user (e.g. `kubernetes`):

```
Nov 10 18:54:31 kube-controller-manager[3568]: W1110 18:54:31.044098    3568 driver-call.go:149] FlexVolume: driver call failed: executable: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds, args: [init], error: fork/exec /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds: permission denied, output: ""
```